### PR TITLE
gitter: use ethersphere/orange-lounge instead of ethereum/swarm

### DIFF
--- a/index.html
+++ b/index.html
@@ -266,7 +266,7 @@ Swarm is under active development.
 <li class="lead">Proof-of-Concept 0.3 was <a href="https://blog.ethereum.org/2018/06/21/announcing-swarm-proof-of-concept-release-3/">released</a> in June, 2018.</li>
 <li class="lead">The <a href="https://github.com/ethersphere/swarm/wiki/Roadmap">Roadmap</a> describes the current status of development, and outlines the path to the upcoming POC releases.</li>
 <li class="lead">Work is progressing on <a href="https://github.com/ethersphere/swarm/wiki/Working-groups">several fronts in parallel</a>. </li>
-<li class="lead">Keep up to date by joining the <a href="https://gitter.im/ethereum/swarm">Swarm gitter channel</a>.</li>
+<li class="lead">Keep up to date by joining the <a href="https://gitter.im/ethersphere/orange-lounge">Swarm gitter channel</a>.</li>
 </ul>
 
 
@@ -505,7 +505,7 @@ Swarm is under active development.
         <div class="col-xs-12 col-md-12 text-left">
           <div class="page-header">
 		  <h1>Contact Information</h1><br>
-		  <p class="lead">The Swarm team is reachable on <a href="https://gitter.im/ethereum/swarm">gitter</a>.
+		  <p class="lead">The Swarm team is reachable on <a href="https://gitter.im/ethersphere/orange-lounge">gitter</a>.
           </div>
         </div>
       </div>


### PR DESCRIPTION
Since we changed Gitter channel in the README.md to ethersphere/orange-lounge, I think we should be consistent, and I am changing it here as well.