### PR TITLE
automatically update release notes with swarm manifest digest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,6 @@ branches:
   - master
   - /v(\d+\.)(\d+\.)(\d)/
 
-env:
-  global:
-    - SWARM_BZZ_API=https://swarm-public-staging.stg.swarm-gateways.net/
-
 stages:
   - name: release
     if: tag IS present

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ stages:
 before_install:
   - sudo add-apt-repository -y ppa:ethereum/ethereum
   - sudo apt-get update
-  - sudo apt-get install -y ethereum-swarm tar
+  - sudo apt-get install -y ethereum-swarm tar jq
 
 before_script:
   - export RELEASE_FILE="swarm-home-$TRAVIS_TAG.tar.gz"

--- a/.travis/deploy.sh
+++ b/.travis/deploy.sh
@@ -6,6 +6,7 @@ SWARM_BZZ_API="https://swarm-public-staging.stg.swarm-gateways.net/"
 GITHUB_ORG="ethersphere"
 GITHUB_REPO="swarm-home"
 GITHUB_USER="${GITHUB_USER:-bzzbot}"
+GITHUB_SECRET="${GITHUB_SECRET:$RELEASE_OAUTH_TOKEN}"
 
 RELEASE_DIR=$(mktemp -d)
 RELEASE_FILE="swarm-home-$TAG.tar.gz"
@@ -22,7 +23,7 @@ SWARM_MANIFEST=$(swarm --bzzapi $SWARM_BZZ_API --defaultpath "$RELEASE_DIR/index
 RID=$(curl -s https://api.github.com/repos/$GITHUB_ORG/$GITHUB_REPO/releases/tags/v1.0.2 | jq '.id')
 
 echo "Updating release notes for release $RID ..."
-curl -u "$GITHUB_USER:$RELEASE_OAUTH_TOKEN" -i -X PATCH \
+curl -u "$GITHUB_USER:$GITHUB_SECRET" -i -X PATCH \
   "https://api.github.com/repos/$GITHUB_ORG/$GITHUB_REPO/releases/$RID" \
   -H "Accept: application/json" \
   -d @- << EOF

--- a/.travis/deploy.sh
+++ b/.travis/deploy.sh
@@ -1,12 +1,34 @@
-#!/bin/bash -xe
+#!/bin/bash -e
+TAG="${TAG:-$TRAVIS_TAG}"
 
-RELEASE_DIR=`mktemp -d`
+SWARM_BZZ_API="https://swarm-public-staging.stg.swarm-gateways.net/"
+
+GITHUB_ORG="ethersphere"
+GITHUB_REPO="swarm-home"
+GITHUB_USER="${GITHUB_USER:-bzzbot}"
+
+RELEASE_DIR=$(mktemp -d)
+RELEASE_FILE="swarm-home-$TAG.tar.gz"
 
 # Download and extract release
-wget -v https://github.com/ethersphere/swarm-home/releases/download/$TRAVIS_TAG/$RELEASE_FILE
-tar -zxvf $RELEASE_FILE -C $RELEASE_DIR
+wget -v "https://github.com/$GITHUB_ORG/$GITHUB_REPO/releases/download/$TAG/$RELEASE_FILE"
+tar -zxvf "$RELEASE_FILE" -C "$RELEASE_DIR"
 
 # Upload to swarm
-swarm --bzzapi $SWARM_BZZ_API \
-      --defaultpath $RELEASE_DIR/index.html \
-      --recursive up $RELEASE_DIR
+echo "Uploading $TAG to swarm..."
+SWARM_MANIFEST=$(swarm --bzzapi $SWARM_BZZ_API --defaultpath "$RELEASE_DIR/index.html" --recursive up "$RELEASE_DIR")
+
+# Update GitHub release description
+RID=$(curl -s https://api.github.com/repos/$GITHUB_ORG/$GITHUB_REPO/releases/tags/v1.0.2 | jq '.id')
+
+echo "Updating release notes for release $RID ..."
+curl -u "$GITHUB_USER:$RELEASE_OAUTH_TOKEN" -i -X PATCH \
+  "https://api.github.com/repos/$GITHUB_ORG/$GITHUB_REPO/releases/$RID" \
+  -H "Accept: application/json" \
+  -d @- << EOF
+{
+  "tag_name": "$TAG",
+  "name": "$TAG",
+  "body": "[\`bzz://$SWARM_MANIFEST\`](https://swarm-gateways.net/bzz:/$SWARM_MANIFEST/)"
+}
+EOF

--- a/README.md
+++ b/README.md
@@ -19,6 +19,3 @@ For example:
 git tag v1.0.0
 git push origin v1.0.0
  ```
-
-
-**Note:** Once the travis job finishes, please check the logs and update the release description so that it includes the swarm manifest digest.


### PR DESCRIPTION
We're now automatically updating the release description to include the digest for the swarm manifest.

See: https://github.com/ethersphere/swarm-home/releases 