### PR TITLE
travis: use auth for github api call, to avoid rate limiting

### DIFF
--- a/.travis/deploy.sh
+++ b/.travis/deploy.sh
@@ -20,7 +20,8 @@ echo "Uploading $TAG to swarm..."
 SWARM_MANIFEST=$(swarm --bzzapi $SWARM_BZZ_API --defaultpath "$RELEASE_DIR/index.html" --recursive up "$RELEASE_DIR")
 
 # Update GitHub release description
-RID=$(curl -s https://api.github.com/repos/$GITHUB_ORG/$GITHUB_REPO/releases/tags/v1.0.2 | jq '.id')
+RID=$(curl -s -u "$GITHUB_USER:$GITHUB_SECRET" \
+      https://api.github.com/repos/$GITHUB_ORG/$GITHUB_REPO/releases/tags/v1.0.2 | jq '.id')
 
 echo "Updating release notes for release $RID ..."
 curl -u "$GITHUB_USER:$GITHUB_SECRET" -i -X PATCH \


### PR DESCRIPTION
Due to the logs from the latest travis job:

```
{
  "message": "API rate limit exceeded for 104.154.113.151. (But here's the good news: Authenticated requests get a higher rate limit. Check out the documentation for more details.)",
  "documentation_url": "https://developer.github.com/v3/#rate-limiting"
}
```