### PR TITLE
homepage: remove redundant gitter line

### DIFF
--- a/index.html
+++ b/index.html
@@ -362,8 +362,6 @@
                   <li>Scan and repair</li>
                   <li>Insurance</li>
                 </ul>
-          <p class="lead">Keep up to date by joining the <a href="https://gitter.im/ethereum/swarm">Swarm gitter channel</a>.</p>
-          </p>
         </div>
       </div>
     </div><!-- //Container -->


### PR DESCRIPTION
No need to add our contact channels all over the page, it is enough that we have them under Contact. Also there are multiple ways to stay up to date with Swarm - Twitter, website, etc.