### PR TITLE
index: link to github projects

### DIFF
--- a/index.html
+++ b/index.html
@@ -326,6 +326,7 @@
                   <p class="lead">Swarm is under active development.</p>
                   <p class="lead">Proof-of-Concept 0.3 was <a href="https://blog.ethereum.org/2018/06/21/announcing-swarm-proof-of-concept-release-3/">released</a> in June, 2018.</p>
                   <p class="lead">Proof-of-Concept 0.4 was released in May, 2019.</p>
+                  <p class="lead">You can follow the project by checking out our <a href="https://github.com/orgs/ethersphere/projects" target="_blank">Project Boards</a> at our <a href="https://github.com/ethersphere" target="_blank">Github Organisation page</a></p>
                   <p>&nbsp;</p>
                   <h2 id="short-term-milestones">Short term milestones</h2>
                   <ul>


### PR DESCRIPTION
The closest thing we have to a public roadmap is our Github Organisation projects, so I am adding a sentence with links to them under our website Roadmap section.