### PR TITLE
homepage: add matomo tracking

### DIFF
--- a/index.html
+++ b/index.html
@@ -67,6 +67,24 @@
     });
   </script>
   <!-- End of SMOOTH SCROLL -->
+
+  <!-- Matomo -->
+  <script type="text/javascript">
+    if (window.location.hostname === 'swarm.ethereum.org') {
+      var _paq = _paq || [];
+      /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+      _paq.push(['trackPageView']);
+      _paq.push(['enableLinkTracking']);
+      (function() {
+        var u="//matomo.datafund.io/";
+        _paq.push(['setTrackerUrl', u+'piwik.php']);
+        _paq.push(['setSiteId', '6']);
+        var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+        g.type='text/javascript'; g.async=true; g.defer=true; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s);
+      })();
+    };
+  </script>
+  <!-- End Matomo Code -->
 </head>
 
 <body class="">


### PR DESCRIPTION
This PR adds a Matomo tracking code requested by the comms team.

I have added a check on `window.location.hostname === 'swarm.ethereum.org'` to avoid calling the tracker by opening a page on swarm gateways or local swarm nodes.